### PR TITLE
Add basic index page with navigation menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CargoClarity</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 0;
+      background: #f6f7fb;
+      color: #1f2937;
+    }
+
+    header {
+      background: #111827;
+      padding: 16px 24px;
+    }
+
+    nav {
+      display: flex;
+      gap: 24px;
+    }
+
+    nav a {
+      color: #f9fafb;
+      text-decoration: none;
+      font-weight: 600;
+      padding: 6px 0;
+      border-bottom: 2px solid transparent;
+    }
+
+    nav a:hover,
+    nav a:focus {
+      border-bottom-color: #38bdf8;
+    }
+
+    main {
+      padding: 48px 24px;
+    }
+
+    h1 {
+      margin-top: 0;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <nav aria-label="Main menu">
+      <a href="#about">About Us</a>
+      <a href="#documents">Documents</a>
+      <a href="#help">Help</a>
+    </nav>
+  </header>
+  <main>
+    <h1>Welcome to CargoClarity</h1>
+    <p>Select a menu item above to learn more.</p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Add a simple landing page to provide basic site navigation for About Us, Documents, and Help.

### Description
- Add `index.html` containing a header navigation with links for About Us, Documents, and Help and minimal inline CSS for layout and hover states.

### Testing
- Rendered the page with `python -m http.server` and verified a browser render using Playwright by capturing a screenshot, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697386c9c3cc832784facf6444597625)